### PR TITLE
fix: update catalystcommunity/app-utils-go version to 1.0.9

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -50,17 +50,17 @@ jobs:
           ./semver-tags run --dry_run --github_action | yq -P -o=json "."
       - name: tags-output
         run: |
-          echo "new_release_published: ${{ steps.semver-tags.outputs.new_release_published }}"
-          echo "new_release_version: ${{ steps.semver-tags.outputs.new_release_version }}"
-          echo "new_release_major_version: ${{ steps.semver-tags.outputs.new_release_major_version }}"
-          echo "new_release_published: ${{ steps.semver-tags.outputs.new_release_published }}"
-          echo "new_release_patch_version: ${{ steps.semver-tags.outputs.new_release_patch_version }}"
-          echo "new_release_git_head: ${{ steps.semver-tags.outputs.new_release_git_head }}"
-          echo "new_release_git_tag: ${{ steps.semver-tags.outputs.new_release_git_tag }}"
-          echo "last_release_version: ${{ steps.semver-tags.outputs.last_release_version }}"
-          echo "last_release_git_head: ${{ steps.semver-tags.outputs.last_release_git_head }}"
-          echo "last_release_git_tag: ${{ steps.semver-tags.outputs.last_release_git_tag }}"
-          echo "dry_run: ${{ steps.semver-tags.outputs.dry_run }}"
-          echo "new_release_notes_json: ${{ steps.semver-tags.outputs.new_release_notes_json }}"
-          echo "new_release_notes: ${{ steps.semver-tags.outputs.new_release_notes }}"
+          echo 'new_release_published: ${{ steps.semver-tags.outputs.new_release_published }}'
+          echo 'new_release_version: ${{ steps.semver-tags.outputs.new_release_version }}'
+          echo 'new_release_major_version: ${{ steps.semver-tags.outputs.new_release_major_version }}'
+          echo 'new_release_published: ${{ steps.semver-tags.outputs.new_release_published }}'
+          echo 'new_release_patch_version: ${{ steps.semver-tags.outputs.new_release_patch_version }}'
+          echo 'new_release_git_head: ${{ steps.semver-tags.outputs.new_release_git_head }}'
+          echo 'new_release_git_tag: ${{ steps.semver-tags.outputs.new_release_git_tag }}'
+          echo 'last_release_version: ${{ steps.semver-tags.outputs.last_release_version }}'
+          echo 'last_release_git_head: ${{ steps.semver-tags.outputs.last_release_git_head }}'
+          echo 'last_release_git_tag: ${{ steps.semver-tags.outputs.last_release_git_tag }}'
+          echo 'dry_run: ${{ steps.semver-tags.outputs.dry_run }}'
+          echo 'new_release_notes_json: ${{ steps.semver-tags.outputs.new_release_notes_json }}'
+          echo 'new_release_notes: ${{ steps.semver-tags.outputs.new_release_notes }}'
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/catalystcommunity/semver-tags
 go 1.20
 
 require (
-	github.com/catalystcommunity/app-utils-go v1.0.7
+	github.com/catalystcommunity/app-utils-go v1.0.9
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/catalystcommunity/app-utils-go v1.0.7 h1:oOJBcA8tbb4QjJ8J5MHilMcd1k3l1fz7kcBMONlZ104=
-github.com/catalystcommunity/app-utils-go v1.0.7/go.mod h1:zJwtRgtrC5qNCjiKY9N9vQqxruNyvZvG779aYlcHbcs=
+github.com/catalystcommunity/app-utils-go v1.0.9 h1:0WgpT1XMloyu0BYEwmF3h21LjX0zKZ1qZ9iDSPW6bys=
+github.com/catalystcommunity/app-utils-go v1.0.9/go.mod h1:6TUs51pXf4+24a5qPBAU/qlH738WrrQBa2JcVDSoot0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
Update catalystcommunity/app-utils-go version to fix path mismatch from move to catalystcommunity org

I was getting this error from `go mod verify`:
```
go: github.com/catalystcommunity/app-utils-go@v1.0.7: parsing go.mod:
        module declares its path as: github.com/catalystsquad/app-utils-go
                but was required as: github.com/catalystcommunity/app-utils-go
```

PR workflow now also escapes the tags-output echoes.