### PR TITLE
fix: atomic push tags, with the commits on branch

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,6 +29,7 @@ type runCmdConfig struct {
 	DryRun           bool
 	GithubAction     bool
 	OutputJson       bool
+	Atomic           bool
 	PreReleaseString string
 	BuildString      string
 	Remote           string
@@ -42,6 +43,7 @@ func init() {
 	runCmd.PersistentFlags().Bool("dry_run", false, "when true, do not do any tagging or writing to changelog")
 	runCmd.PersistentFlags().Bool("github_action", false, "when true, make github action outputs for use in other steps")
 	runCmd.PersistentFlags().Bool("output_json", true, "when true, print a json object of results, including dry_run status")
+	runCmd.PersistentFlags().Bool("atomic", true, "when true, uses the --atomic flag with git push, otherwise uses a regular push")
 	runCmd.PersistentFlags().String("pre_release_string", "", "the string that represents the pre-release part of the semver")
 	runCmd.PersistentFlags().String("build_string", "", "the string that represents the build part of the semver")
 	runCmd.PersistentFlags().String("remote", "origin", "the name of the remote to push to")
@@ -65,6 +67,7 @@ func initRunCmdConfig() *runCmdConfig {
 	config.DryRun = viper.GetBool("dry_run")
 	config.GithubAction = viper.GetBool("github_action")
 	config.OutputJson = viper.GetBool("output_json")
+	config.Atomic = viper.GetBool("atomic")
 	config.PreReleaseString = viper.GetString("pre_release_string")
 	config.BuildString = viper.GetString("build_string")
 	config.Remote = viper.GetString("remote")
@@ -79,7 +82,17 @@ func initRunCmdConfig() *runCmdConfig {
 
 func runCommand(config *runCmdConfig) {
 	logging.Log.WithField("settings", fmt.Sprintf("%+v", *config)).Info("command run with settings resolved")
-	err := core.DoTagging(config.DryRun, config.GithubAction, config.OutputJson, config.PreReleaseString, config.BuildString, config.Remote, config.Branch, config.Directories)
+	err := core.DoTagging(
+		config.DryRun,
+		config.GithubAction,
+		config.OutputJson,
+		config.Atomic,
+		config.PreReleaseString,
+		config.BuildString,
+		config.Remote,
+		config.Branch,
+		config.Directories,
+	)
 	if err != nil {
 		logging.Log.WithError(err).Error("error checking commits")
 		os.Exit(1)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,6 +31,8 @@ type runCmdConfig struct {
 	OutputJson       bool
 	PreReleaseString string
 	BuildString      string
+	Remote           string
+	Branch           string
 	AllowedTypes     []string
 	Directories      []string
 }
@@ -42,6 +44,8 @@ func init() {
 	runCmd.PersistentFlags().Bool("output_json", true, "when true, print a json object of results, including dry_run status")
 	runCmd.PersistentFlags().String("pre_release_string", "", "the string that represents the pre-release part of the semver")
 	runCmd.PersistentFlags().String("build_string", "", "the string that represents the build part of the semver")
+	runCmd.PersistentFlags().String("remote", "origin", "the name of the remote to push to")
+	runCmd.PersistentFlags().String("branch", "main", "the name of the branch to push to")
 	runCmd.PersistentFlags().StringArray("allowed_types", []string{"fix", "feat", "chore", "build", "docs", "ci"}, "conventional commit types allowed")
 	runCmd.PersistentFlags().StringArray("directories", []string{}, "the subdirectories to apply tags for, which makes github action outputs comma separated")
 
@@ -63,6 +67,8 @@ func initRunCmdConfig() *runCmdConfig {
 	config.OutputJson = viper.GetBool("output_json")
 	config.PreReleaseString = viper.GetString("pre_release_string")
 	config.BuildString = viper.GetString("build_string")
+	config.Remote = viper.GetString("remote")
+	config.Branch = viper.GetString("branch")
 	config.AllowedTypes = viper.GetStringSlice("allowed_types")
 	config.Directories = viper.GetStringSlice("directories")
 
@@ -73,7 +79,7 @@ func initRunCmdConfig() *runCmdConfig {
 
 func runCommand(config *runCmdConfig) {
 	logging.Log.WithField("settings", fmt.Sprintf("%+v", *config)).Info("command run with settings resolved")
-	err := core.DoTagging(config.DryRun, config.GithubAction, config.OutputJson, config.PreReleaseString, config.BuildString, config.Directories)
+	err := core.DoTagging(config.DryRun, config.GithubAction, config.OutputJson, config.PreReleaseString, config.BuildString, config.Remote, config.Branch, config.Directories)
 	if err != nil {
 		logging.Log.WithError(err).Error("error checking commits")
 		os.Exit(1)

--- a/core/check_commits.go
+++ b/core/check_commits.go
@@ -384,7 +384,17 @@ func SetGithubActionOutputs(results Outputs) {
 	gha.SetOutput("last_release_git_tag", results.Last_release_git_tag)
 }
 
-func DoTagging(DryRun bool, GithubAction bool, OutputJson bool, PreReleaseString string, BuildString string, Remote string, Branch string, Directories []string) error {
+func DoTagging(
+	DryRun bool,
+	GithubAction bool,
+	OutputJson bool,
+	Atomic bool,
+	PreReleaseString string,
+	BuildString string,
+	Remote string,
+	Branch string,
+	Directories []string,
+) error {
 	// Make sure we're in a git repo with a git command or this is pointless
 	if !IsGitRepo() {
 		return errors.New("current directory is not a git repo, nothing to do")
@@ -465,9 +475,15 @@ func DoTagging(DryRun bool, GithubAction bool, OutputJson bool, PreReleaseString
 	// We don't need to push tags if this is a dry run
 	if !DryRun {
 		tags := strings.Split(Outputs.New_release_git_tag, ",")
-		cmdArgs := []string{"push", "--atomic", Remote, Branch}
+		cmdArgs := []string{"push"}
+		if Atomic {
+			cmdArgs = append(cmdArgs, "--atomic")
+		}
+		cmdArgs = append(cmdArgs, []string{Remote, Branch}...)
 		cmdArgs = append(cmdArgs, tags...)
+		logging.Log.Info(fmt.Sprintf("Some test string: %s", strings.Join(cmdArgs, " ")))
 		// All tags should be there, so push! This prevents tags being pushed if there were errors
+		// Ex. cmd: git push --atomic origin main tagOne tagTwo
 		cmd := exec.Command("git", cmdArgs...)
 		output, err := cmd.Output()
 		if err != nil {

--- a/core/check_commits.go
+++ b/core/check_commits.go
@@ -481,7 +481,6 @@ func DoTagging(
 		}
 		cmdArgs = append(cmdArgs, []string{Remote, Branch}...)
 		cmdArgs = append(cmdArgs, tags...)
-		logging.Log.Info(fmt.Sprintf("Some test string: %s", strings.Join(cmdArgs, " ")))
 		// All tags should be there, so push! This prevents tags being pushed if there were errors
 		// Ex. cmd: git push --atomic origin main tagOne tagTwo
 		cmd := exec.Command("git", cmdArgs...)

--- a/core/check_commits.go
+++ b/core/check_commits.go
@@ -384,7 +384,7 @@ func SetGithubActionOutputs(results Outputs) {
 	gha.SetOutput("last_release_git_tag", results.Last_release_git_tag)
 }
 
-func DoTagging(DryRun bool, GithubAction bool, OutputJson bool, PreReleaseString string, BuildString string, Directories []string) error {
+func DoTagging(DryRun bool, GithubAction bool, OutputJson bool, PreReleaseString string, BuildString string, Remote string, Branch string, Directories []string) error {
 	// Make sure we're in a git repo with a git command or this is pointless
 	if !IsGitRepo() {
 		return errors.New("current directory is not a git repo, nothing to do")
@@ -464,8 +464,11 @@ func DoTagging(DryRun bool, GithubAction bool, OutputJson bool, PreReleaseString
 	Outputs := GenerateOutputs(results, DryRun)
 	// We don't need to push tags if this is a dry run
 	if !DryRun {
+		tags := strings.Split(Outputs.New_release_git_tag, ",")
+		cmdArgs := []string{"push", "--atomic", Remote, Branch}
+		cmdArgs = append(cmdArgs, tags...)
 		// All tags should be there, so push! This prevents tags being pushed if there were errors
-		cmd := exec.Command("git", "push", "--tags")
+		cmd := exec.Command("git", cmdArgs...)
 		output, err := cmd.Output()
 		if err != nil {
 			return fmt.Errorf("error pushing tags: %s\n%s", err, string(output))


### PR DESCRIPTION
This change uses `git push --atomic` to push tags along with any commits for a branch to a specific remote.  The `--atomic` flag requests that _all_ refs need to be updated to be accepted. See the [`--atomic` docs here.](https://git-scm.com/docs/git-push#Documentation/git-push.txt---no-atomic)

Not every server supports atomic pushes which would fail, so I'm adding a default true `--atomic` boolean flag to semver-tags as well to allow disabling this behavior, to avoid failures for that edge case.

The default remote and branch is `origin main` but users can override these with `--remote` and `--branch`

These changes let people use the outputs of a `--dry_run` to update files with new versions and have _that_ commit be tagged for consistency. A helm chart in my case. The workflow would look like so:
- semver-tags with a dry_run
- use outputs to update chart, and commit updates
- run semver-tags again for realsies, which will atomically push

This also makes it a bit more explicit if a user has multiple remotes that they would need to run `git push secondRemote --tags` to get the tags over there too. Which was already the case, [because git defaults to `origin`.](https://git-scm.com/docs/git-push#_description)