### PR TITLE
fix: when failing to push tags, include the stderr from git in the error message

### DIFF
--- a/core/check_commits.go
+++ b/core/check_commits.go
@@ -507,7 +507,7 @@ func DoTagging(
 
 		err = cmd.Wait()
 		if err != nil {
-			return fmt.Errorf("error pushing tags: %s\n%s\n%s", err, string(output), string(cmdErrOut))
+			return fmt.Errorf("error pushing tags: %sn%s\n%s", err, string(output), string(cmdErrOut))
 		}
 	}
 

--- a/core/check_commits.go
+++ b/core/check_commits.go
@@ -507,7 +507,7 @@ func DoTagging(
 
 		err = cmd.Wait()
 		if err != nil {
-			return fmt.Errorf("error pushing tags: %sn%s\n%s", err, string(output), string(cmdErrOut))
+			return fmt.Errorf("error pushing tags: %s\n%s\n%s", err, string(output), string(cmdErrOut))
 		}
 	}
 


### PR DESCRIPTION
This changes the error when failing to push tags to also include the `stderr` output from the `git push` subcommand. This makes debugging workflows much easier.

How we run the command is pretty much the same, just more verbose.

Before, the error would look like this (taken from [this action run](https://github.com/catalystcommunity/corndogs/actions/runs/12937894443/job/36086838723#step:5:14) in the corndogs repo):
```
INFO[2025-01-23T20:55:38Z] Tagging new version: corndogs/v0.1.2         
ERRO[2025-01-23T20:55:38Z] error checking commits                        error="error pushing tags: exit status 1\n"
Error: Process completed with exit code 1.
```

Modifying the command to force a failure, now it would look like this:
```
ERRO[2025-01-23T15:00:44-07:00] error checking commits                        error="error pushing tags: exit status 1\n\ngit: 'pusheth' is not a git command. See 'git --help'.\n"
```