### PR TITLE
fix: add ci commit type to update patch version

### DIFF
--- a/core/check_commits.go
+++ b/core/check_commits.go
@@ -99,7 +99,7 @@ func AnalyzeCommitMessage(message string) semver.CommitType {
 	}
 
 	switch commitType {
-	case "fix", "chore", "docs", "style", "refactor", "test", "revert":
+	case "fix", "chore", "ci", "docs", "style", "refactor", "test", "revert":
 		return semver.Patch
 	case "feat":
 		return semver.Minor


### PR DESCRIPTION
The `ci` commit type seems semantically similar to `chore`, and fitting as a patch level update.
It's included in our default `allowed_types`, and it is convenient to have `ci(scope)` instead of just using `chore(ci)` or something for everything.