### PR TITLE
feat: explicit target naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,44 @@ multiple paths when the first path basename is the required tag name.
 
 ## Commit Types
 
-The command reads conventional commits. A `feat` commit increases the minor
-version. Each other known type increases the patch version. A `!` after the
-type, and a `BREAKING CHANGE:` subject, increase the major version.
+The command reads [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+A `fix` commit increases the patch version. A `feat` commit increases the minor
+version. These two bump levels are fixed.
 
-The known types are `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
-`refactor`, `revert`, `style`, and `test`. Use `--allowed_types` to make the
-list shorter. A commit with a type outside the list does not change the
-version.
+A `!` after the type or scope increases the major version. A
+`BREAKING CHANGE:` or `BREAKING-CHANGE:` footer also increases the major
+version. `BREAKING CHANGE` is in the default allowed-type list.
+
+By default, these types make a patch release: `build`, `chore`, `ci`, `docs`,
+`fix`, `perf`, `refactor`, `revert`, `style`, and `test`. The `feat` type makes
+a minor release. No ordinary type makes a major release by default.
+
+Use `--patch_types`, `--minor_types`, and `--major_types` to configure other
+types. Each flag is repeatable and also accepts comma-separated values. A value
+replaces the default list for that level. The command always adds `fix` to the
+patch list and `feat` to the minor list.
 
 ```sh
-semver-tags run --allowed_types fix --allowed_types feat
+semver-tags run \
+  --patch_types "fix,holiday" \
+  --minor_types "feat,meatball" \
+  --major_types earthquake
 ```
+
+This example makes `holiday` a patch change, `meatball` a minor change, and
+`earthquake` a major change.
+
+Use `--allowed_types` to limit the configured types that can change a version.
+A commit with a type outside this list does not change the version. If you do
+not set `allowed_types`, all configured types and `BREAKING CHANGE` are
+allowed.
+
+```sh
+semver-tags run --allowed_types fix --allowed_types "holiday,BREAKING CHANGE"
+```
+
+If you set `allowed_types`, include `BREAKING CHANGE` to permit breaking
+markers.
 
 ## Configuration File
 
@@ -118,6 +144,21 @@ that `--config` names. Each key is a flag name.
 
 ```yaml
 dry_run: true
+patch_types:
+  - fix
+  - holiday
+minor_types:
+  - feat
+  - meatball
+major_types:
+  - earthquake
+allowed_types:
+  - fix
+  - feat
+  - holiday
+  - meatball
+  - earthquake
+  - BREAKING CHANGE
 directories:
   - services/api
 dir_group:
@@ -134,7 +175,8 @@ A flag on the command line replaces the value in the file.
 ## Environment Variables
 
 Each flag also reads an environment variable. The variable name is the flag
-name in capital letters. A flag on the command line replaces the variable.
+name in capital letters. An underscore replaces a hyphen. A flag on the
+command line replaces the variable.
 
 ```sh
 DRY_RUN=true BRANCH=main semver-tags run
@@ -175,6 +217,20 @@ Command-line `--target` values replace `TARGETS` and file `targets` values.
 A path with a space does not work in `DIRECTORIES` or `DIR_GROUP`. Use the
 flags for that path.
 
+The commit-type settings also have environment variables. A space separates
+their values:
+
+```sh
+PATCH_TYPES="fix holiday" \
+MINOR_TYPES="feat meatball" \
+MAJOR_TYPES="earthquake" \
+ALLOWED_TYPES="fix feat holiday meatball earthquake BREAKING-CHANGE" \
+  semver-tags run
+```
+
+The environment form uses `BREAKING-CHANGE` as an alias because
+`BREAKING CHANGE` contains a space.
+
 ## Outputs
 
 The command writes one JSON object. Each field holds one value for each group,
@@ -193,6 +249,38 @@ the command pushes nothing.
 By default the command also pushes the branch that `--branch` names. Set
 `--branch ""` to push only the tags. Use this in a CI job that checked out a
 commit instead of a branch.
+
+## Short Version Tags
+
+Use `--short-versions` to update mutable major and minor tags. A release tag of
+`v1.3.7` also updates `v1.3` and `v1`. A package release of `api/v1.3.7` also
+updates `api/v1.3` and `api/v1`.
+
+```sh
+semver-tags run --short-versions
+```
+
+The command force-updates short tags because they move to each new release.
+It sends the full tag and the short tags in the same atomic push when
+`--atomic` is true. Output fields continue to contain the full version tag.
+
+Short tags are off by default in this major version. They will be on by
+default in the next major version. When neither short-version flag is set, the
+command writes a migration warning to standard output. Use
+`--skip-short-versions` to keep only full tags and suppress this warning. You
+can also set `LOG_LEVEL=ERROR` to suppress the warning. Set one of these values
+before you parse JSON output.
+
+```sh
+semver-tags run --skip-short-versions
+```
+
+The `--skip-short-versions` flag will remain available in the next major
+version. It will not remain available in later major versions. Do not use
+`--short-versions` and `--skip-short-versions` together.
+
+The configuration-file keys are `short_versions` and `skip_short_versions`.
+The environment variables are `SHORT_VERSIONS` and `SKIP_SHORT_VERSIONS`.
 
 ## Continuous Integration
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 Do an analysis of a repo or its subdirs and generate git tags for semantic versioning based on conventional commits. Oh, and release notes generated.
 
 ## Features
-* Analyze a repo, or a set of directories in a repo and generate semantic version tags.
-* Group more than one directory under one tag with `--dir_group`, so a shared library releases each package that uses it.
-* In github action mode, set outputs for use in other github action steps
-* Generate releaase notes
+- Analyze a repository or a set of paths and generate semantic version tags.
+- Group more than one directory under one tag with `--dir_group`.
+- Give a release target a public name that does not depend on a path name.
+- Set outputs for other GitHub Actions steps.
+- Generate release notes.
 
 ## Directories
 
@@ -46,6 +47,55 @@ shared library on its own as well, name it in a `--directories` flag too.
 Every group must make a different tag name. The command stops with an error if
 two groups make the same tag name.
 
+## Named Targets
+
+Use a named target when the public release name must not depend on a source
+path. A target has one name and one or more paths. A path can name a file or a
+directory. A commit in any target path affects that target.
+
+Use `targets` in `.semver-tags.yaml` for the full configuration form:
+
+```yaml
+targets:
+  - name: public-api
+    paths:
+      - services/api
+      - libs/shared
+      - README.md
+  - name: public-worker
+    paths:
+      - services/worker
+      - libs/shared
+```
+
+This configuration can make the tags `public-api/v1.2.3` and
+`public-worker/v2.1.0`. A commit in `libs/shared` affects both targets.
+
+Use the repeatable `--target` flag for the compact command-line form:
+
+```sh
+semver-tags run \
+  --target "public-api=services/api,libs/shared" \
+  --target "public-worker=services/worker,libs/shared"
+```
+
+The compact form uses the first `=` to separate the name from the paths. A
+comma separates the paths. The compact form has no escape syntax. Use the
+configuration file if a path contains a comma.
+
+A target name must start with a letter or digit. It can contain letters,
+digits, dots, underscores, and hyphens. It cannot contain `..`, and it cannot
+end with a dot or `.lock`. Each target path is relative to the Git root. Use
+forward slashes. A path of `.` includes the full repository.
+
+You can use `--directories`, `--dir_group`, and named targets in one run. Each
+release name must be unique. The output order is `directories`, `dir_group`,
+and then `targets`.
+
+The `directories` and `dir_group` settings remain supported. Use `directories`
+for one path when its basename is the required tag name. Use `dir_group` for
+multiple paths when the first path basename is the required tag name.
+
 ## Commit Types
 
 The command reads conventional commits. A `feat` commit increases the minor
@@ -72,6 +122,11 @@ directories:
   - services/api
 dir_group:
   - services/worker,libs/shared
+targets:
+  - name: public-tools
+    paths:
+      - tools/cli
+      - libs/shared
 ```
 
 A flag on the command line replaces the value in the file.
@@ -85,8 +140,9 @@ name in capital letters. A flag on the command line replaces the variable.
 DRY_RUN=true BRANCH=main semver-tags run
 ```
 
-For `DIRECTORIES` and `DIR_GROUP`, a space separates the values. A comma keeps
-its meaning inside one `DIR_GROUP` value. These two commands do the same thing:
+For `DIRECTORIES`, `DIR_GROUP`, and `TARGETS`, a space separates the values. A
+comma keeps its meaning inside one `DIR_GROUP` or `TARGETS` value. These two
+commands do the same thing:
 
 ```sh
 semver-tags run \
@@ -101,14 +157,29 @@ DIR_GROUP="services/api,libs/shared services/worker,libs/shared" \
   semver-tags run
 ```
 
-A directory path with a space in it does not work in these variables. Use the
-flags for such a path.
+Use this form for named targets:
+
+```sh
+TARGETS="public-api=services/api,libs/shared public-worker=services/worker,libs/shared" \
+  semver-tags run
+```
+
+`TARGETS` uses a space between targets, the first `=` between a name and its
+paths, and a comma between paths. It has no escape syntax. A path that contains
+a space or comma does not work in this variable. Use the structured
+configuration-file form for that path.
+
+Command-line `--target` values replace `TARGETS` and file `targets` values.
+`TARGETS` values replace file `targets` values.
+
+A path with a space does not work in `DIRECTORIES` or `DIR_GROUP`. Use the
+flags for that path.
 
 ## Outputs
 
 The command writes one JSON object. Each field holds one value for each group,
-separated by commas. The order is every `--directories` value first, then every
-`--dir_group` value.
+separated by commas. The order is every `directories` value first, then every
+`dir_group` value, and then every named target.
 
 ```sh
 semver-tags run --dry_run --output_json --dir_group "services/api,libs/shared"

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -59,9 +59,25 @@ flag for more targets.
 The first target can make public-api/v1.2.3. A commit in libs/shared affects
 both targets. A target path can name a file or a directory.
 
-The outputs hold one value for each group or target, separated by commas. The order is
-every --directories value first, then every --dir_group value, and then every
---target value.`,
+The fix type always makes a patch release. The feat type always makes a minor
+release. Use --patch_types, --minor_types, and --major_types to configure other
+types. For example:
+
+  semver-tags run --patch_types fix --patch_types holiday
+
+Use --allowed_types to limit which configured types can make a release. The
+flag is repeatable and also accepts comma-separated values. BREAKING CHANGE is
+allowed by default and makes a major release.
+
+Use --short-versions to update mutable major and minor tags with each release.
+For v1.3.7, the command also updates v1.3 and v1. This behavior will become the
+default in the next major version. Until then, the command writes a migration
+warning when neither short-version flag is set. Use --skip-short-versions to
+keep only full tags and suppress the warning.
+
+The outputs hold one value for each group or target, separated by commas. The
+order is every --directories value first, then every --dir_group value, and
+then every --target value.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		config, err := initRunConfig(cmd)
 		if err != nil {
@@ -82,7 +98,12 @@ func init() {
 	runCmd.PersistentFlags().String("build_string", "", "the string that represents the build part of the semver")
 	runCmd.PersistentFlags().String("remote", "origin", "the name of the remote to push to")
 	runCmd.PersistentFlags().String("branch", "main", "the name of the branch to push to, set it empty to push only the tags")
-	runCmd.PersistentFlags().StringArray("allowed_types", core.DefaultAllowedTypes(), "the conventional commit types that change a version, a type outside the list changes nothing")
+	runCmd.PersistentFlags().StringArray("allowed_types", []string{}, "the commit types that can change a version, repeat the flag or use commas, defaults to all configured types and BREAKING CHANGE")
+	runCmd.PersistentFlags().StringArray("patch_types", core.DefaultPatchTypes(), "the commit types that make a patch release, repeat the flag or use commas; fix always makes a patch release")
+	runCmd.PersistentFlags().StringArray("minor_types", core.DefaultMinorTypes(), "the commit types that make a minor release, repeat the flag or use commas; feat always makes a minor release")
+	runCmd.PersistentFlags().StringArray("major_types", core.DefaultMajorTypes(), "the commit types that make a major release, repeat the flag or use commas")
+	runCmd.PersistentFlags().Bool("short-versions", false, "also update mutable vMAJOR.MINOR and vMAJOR tags")
+	runCmd.PersistentFlags().Bool("skip-short-versions", false, "keep full version tags only and suppress the short-version migration warning")
 	runCmd.PersistentFlags().StringArray("directories", []string{}, "one subdirectory to apply its own tag for, named after the last part of the path, repeat the flag for more tags, which makes github action outputs comma separated")
 	runCmd.PersistentFlags().StringArray("dir_group", []string{}, "a comma separated list of subdirectories that share one tag, named after the first directory in the list, repeat the flag for more tag groups, which makes github action outputs comma separated")
 	runCmd.PersistentFlags().StringArray("target", []string{}, "a named release target in name=path[,path...] form, repeat the flag for more targets")
@@ -93,6 +114,15 @@ func init() {
 	if err != nil {
 		logging.Log.WithError(err).Error("error initializing configuration")
 		panic(err)
+	}
+	for key, flagName := range map[string]string{
+		"short_versions":      "short-versions",
+		"skip_short_versions": "skip-short-versions",
+	} {
+		if err := viper.BindPFlag(key, runCmd.PersistentFlags().Lookup(flagName)); err != nil {
+			logging.Log.WithError(err).Error("error initializing configuration")
+			panic(err)
+		}
 	}
 }
 
@@ -109,8 +139,14 @@ func resolveTargetConfigs(cmd *cobra.Command) ([]core.TargetConfig, error) {
 		return core.ParseTargetSpecifications(strings.Fields(value))
 	}
 
+	return configuredTargets(viper.UnmarshalKey)
+}
+
+func configuredTargets(
+	unmarshalKey func(string, any, ...viper.DecoderConfigOption) error,
+) ([]core.TargetConfig, error) {
 	var targets []core.TargetConfig
-	if err := viper.UnmarshalKey("targets", &targets); err != nil {
+	if err := unmarshalKey("targets", &targets); err != nil {
 		return nil, fmt.Errorf("can not read targets from the configuration file: %w", err)
 	}
 	return targets, nil
@@ -123,18 +159,23 @@ func initRunConfig(cmd *cobra.Command) (core.Config, error) {
 	}
 
 	config := core.Config{
-		DryRun:           viper.GetBool("dry_run"),
-		GithubAction:     viper.GetBool("github_action"),
-		OutputJson:       viper.GetBool("output_json"),
-		Atomic:           viper.GetBool("atomic"),
-		PreReleaseString: viper.GetString("pre_release_string"),
-		BuildString:      viper.GetString("build_string"),
-		Remote:           viper.GetString("remote"),
-		Branch:           viper.GetString("branch"),
-		AllowedTypes:     viper.GetStringSlice("allowed_types"),
-		Directories:      viper.GetStringSlice("directories"),
-		DirGroups:        viper.GetStringSlice("dir_group"),
-		Targets:          targets,
+		DryRun:            viper.GetBool("dry_run"),
+		GithubAction:      viper.GetBool("github_action"),
+		OutputJson:        viper.GetBool("output_json"),
+		Atomic:            viper.GetBool("atomic"),
+		PreReleaseString:  viper.GetString("pre_release_string"),
+		BuildString:       viper.GetString("build_string"),
+		Remote:            viper.GetString("remote"),
+		Branch:            viper.GetString("branch"),
+		AllowedTypes:      viper.GetStringSlice("allowed_types"),
+		PatchTypes:        viper.GetStringSlice("patch_types"),
+		MinorTypes:        viper.GetStringSlice("minor_types"),
+		MajorTypes:        viper.GetStringSlice("major_types"),
+		ShortVersions:     viper.GetBool("short_versions"),
+		SkipShortVersions: viper.GetBool("skip_short_versions"),
+		Directories:       viper.GetStringSlice("directories"),
+		DirGroups:         viper.GetStringSlice("dir_group"),
+		Targets:           targets,
 	}
 
 	logging.Log.WithField("settings", fmt.Sprintf("%+v", config)).Debug("viper settings")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/catalystcommunity/app-utils-go/logging"
 	"github.com/catalystcommunity/semver-tags/core"
@@ -19,8 +20,8 @@ var runCmd = &cobra.Command{
 	Short: "Run the cli",
 	Long: `Runs the cli as a straight shot attempt.
 
-With no --directories and no --dir_group, the command analyzes the whole
-repository and makes one tag, for example v1.2.3.
+With no --directories, --dir_group, or --target value, the command analyzes
+the whole repository and makes one tag, for example v1.2.3.
 
 Use --directories to give one subdirectory its own tag. Give the flag one time
 for each tag you want. The last part of the directory path names the tag.
@@ -47,10 +48,27 @@ each group makes its own tag.
 You can use both flags in the same run. Every group must make a different tag
 name. The command stops with an error if two groups make the same tag name.
 
-The outputs hold one value for each group, separated by commas. The order is
-every --directories value first, then every --dir_group value.`,
+Use --target when a public tag name must not depend on a path name. Put the
+name before an equals sign. Separate multiple paths with commas. Repeat the
+flag for more targets.
+
+  semver-tags run \
+    --target "public-api=services/api,libs/shared" \
+    --target "public-worker=services/worker,libs/shared"
+
+The first target can make public-api/v1.2.3. A commit in libs/shared affects
+both targets. A target path can name a file or a directory.
+
+The outputs hold one value for each group or target, separated by commas. The order is
+every --directories value first, then every --dir_group value, and then every
+--target value.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		runCommand(initRunConfig())
+		config, err := initRunConfig(cmd)
+		if err != nil {
+			logging.Log.WithError(err).Error("error resolving configuration")
+			os.Exit(1)
+		}
+		runCommand(config)
 	},
 }
 
@@ -67,6 +85,7 @@ func init() {
 	runCmd.PersistentFlags().StringArray("allowed_types", core.DefaultAllowedTypes(), "the conventional commit types that change a version, a type outside the list changes nothing")
 	runCmd.PersistentFlags().StringArray("directories", []string{}, "one subdirectory to apply its own tag for, named after the last part of the path, repeat the flag for more tags, which makes github action outputs comma separated")
 	runCmd.PersistentFlags().StringArray("dir_group", []string{}, "a comma separated list of subdirectories that share one tag, named after the first directory in the list, repeat the flag for more tag groups, which makes github action outputs comma separated")
+	runCmd.PersistentFlags().StringArray("target", []string{}, "a named release target in name=path[,path...] form, repeat the flag for more targets")
 
 	// bind flags
 	err := viper.BindPFlags(runCmd.PersistentFlags())
@@ -77,7 +96,32 @@ func init() {
 	}
 }
 
-func initRunConfig() core.Config {
+func resolveTargetConfigs(cmd *cobra.Command) ([]core.TargetConfig, error) {
+	if cmd.Flags().Changed("target") {
+		values, err := cmd.Flags().GetStringArray("target")
+		if err != nil {
+			return nil, fmt.Errorf("can not read --target: %w", err)
+		}
+		return core.ParseTargetSpecifications(values)
+	}
+
+	if value, found := os.LookupEnv("TARGETS"); found {
+		return core.ParseTargetSpecifications(strings.Fields(value))
+	}
+
+	var targets []core.TargetConfig
+	if err := viper.UnmarshalKey("targets", &targets); err != nil {
+		return nil, fmt.Errorf("can not read targets from the configuration file: %w", err)
+	}
+	return targets, nil
+}
+
+func initRunConfig(cmd *cobra.Command) (core.Config, error) {
+	targets, err := resolveTargetConfigs(cmd)
+	if err != nil {
+		return core.Config{}, err
+	}
+
 	config := core.Config{
 		DryRun:           viper.GetBool("dry_run"),
 		GithubAction:     viper.GetBool("github_action"),
@@ -90,11 +134,12 @@ func initRunConfig() core.Config {
 		AllowedTypes:     viper.GetStringSlice("allowed_types"),
 		Directories:      viper.GetStringSlice("directories"),
 		DirGroups:        viper.GetStringSlice("dir_group"),
+		Targets:          targets,
 	}
 
 	logging.Log.WithField("settings", fmt.Sprintf("%+v", config)).Debug("viper settings")
 
-	return config
+	return config, nil
 }
 
 func runCommand(config core.Config) {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/catalystcommunity/semver-tags/core"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,10 +38,9 @@ func withoutTargetsEnvironment(t *testing.T) {
 
 func TestResolveTargetConfigsFromYamlValue(t *testing.T) {
 	withoutTargetsEnvironment(t)
-	viper.Reset()
-	t.Cleanup(viper.Reset)
-	viper.SetConfigType("yaml")
-	require.NoError(t, viper.ReadConfig(strings.NewReader(`
+	config := viper.New()
+	config.SetConfigType("yaml")
+	require.NoError(t, config.ReadConfig(strings.NewReader(`
 targets:
   - name: public-api
     paths:
@@ -48,13 +48,94 @@ targets:
       - libs/shared
 `)))
 
-	targets, err := resolveTargetConfigs(targetTestCommand(t))
+	targets, err := configuredTargets(config.UnmarshalKey)
 
 	require.NoError(t, err)
 	assert.Equal(t, []core.TargetConfig{{
 		Name:  "public-api",
 		Paths: []string{"services/api", "libs/shared"},
 	}}, targets)
+}
+
+func replaceStringArrayFlag(t *testing.T, name string, values []string) {
+	t.Helper()
+	flag := runCmd.PersistentFlags().Lookup(name)
+	require.NotNil(t, flag)
+	sliceValue, ok := flag.Value.(pflag.SliceValue)
+	require.True(t, ok)
+	previousValues := sliceValue.GetSlice()
+	previousChanged := flag.Changed
+	require.NoError(t, sliceValue.Replace(values))
+	flag.Changed = true
+	t.Cleanup(func() {
+		require.NoError(t, sliceValue.Replace(previousValues))
+		flag.Changed = previousChanged
+	})
+}
+
+func setBoolFlag(t *testing.T, name string, value string) {
+	t.Helper()
+	flag := runCmd.PersistentFlags().Lookup(name)
+	require.NotNil(t, flag)
+	previousValue := flag.Value.String()
+	previousChanged := flag.Changed
+	require.NoError(t, flag.Value.Set(value))
+	flag.Changed = true
+	t.Cleanup(func() {
+		require.NoError(t, flag.Value.Set(previousValue))
+		flag.Changed = previousChanged
+	})
+}
+
+func TestRunConfigUsesAllowedTypesFlag(t *testing.T) {
+	withoutTargetsEnvironment(t)
+	replaceStringArrayFlag(t, "allowed_types", []string{"fix", "holiday"})
+
+	config, err := initRunConfig(targetTestCommand(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"fix", "holiday"}, config.AllowedTypes)
+}
+
+func TestRunConfigUsesBumpTypeEnvironmentVariables(t *testing.T) {
+	withoutTargetsEnvironment(t)
+	t.Setenv("PATCH_TYPES", "fix holiday")
+	t.Setenv("MINOR_TYPES", "feat meatball")
+	t.Setenv("MAJOR_TYPES", "earthquake")
+	t.Setenv("ALLOWED_TYPES", "fix holiday BREAKING-CHANGE")
+	viper.AutomaticEnv()
+
+	config, err := initRunConfig(targetTestCommand(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"fix", "holiday"}, config.PatchTypes)
+	assert.Equal(t, []string{"feat", "meatball"}, config.MinorTypes)
+	assert.Equal(t, []string{"earthquake"}, config.MajorTypes)
+	assert.Equal(t, []string{"fix", "holiday", "BREAKING-CHANGE"}, config.AllowedTypes)
+}
+
+func TestRunConfigUsesShortVersionFlags(t *testing.T) {
+	withoutTargetsEnvironment(t)
+	setBoolFlag(t, "short-versions", "true")
+
+	config, err := initRunConfig(targetTestCommand(t))
+
+	require.NoError(t, err)
+	assert.True(t, config.ShortVersions)
+	assert.False(t, config.SkipShortVersions)
+}
+
+func TestRunConfigUsesShortVersionEnvironmentVariables(t *testing.T) {
+	withoutTargetsEnvironment(t)
+	t.Setenv("SHORT_VERSIONS", "true")
+	t.Setenv("SKIP_SHORT_VERSIONS", "false")
+	viper.AutomaticEnv()
+
+	config, err := initRunConfig(targetTestCommand(t))
+
+	require.NoError(t, err)
+	assert.True(t, config.ShortVersions)
+	assert.False(t, config.SkipShortVersions)
 }
 
 func TestResolveTargetConfigsFromEnvironment(t *testing.T) {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/catalystcommunity/semver-tags/core"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func targetTestCommand(t *testing.T, values ...string) *cobra.Command {
+	t.Helper()
+	command := &cobra.Command{Use: "test"}
+	command.Flags().StringArray("target", nil, "")
+	for _, value := range values {
+		require.NoError(t, command.Flags().Set("target", value))
+	}
+	return command
+}
+
+func withoutTargetsEnvironment(t *testing.T) {
+	t.Helper()
+	value, found := os.LookupEnv("TARGETS")
+	require.NoError(t, os.Unsetenv("TARGETS"))
+	t.Cleanup(func() {
+		if found {
+			require.NoError(t, os.Setenv("TARGETS", value))
+			return
+		}
+		require.NoError(t, os.Unsetenv("TARGETS"))
+	})
+}
+
+func TestResolveTargetConfigsFromYamlValue(t *testing.T) {
+	withoutTargetsEnvironment(t)
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.SetConfigType("yaml")
+	require.NoError(t, viper.ReadConfig(strings.NewReader(`
+targets:
+  - name: public-api
+    paths:
+      - services/api
+      - libs/shared
+`)))
+
+	targets, err := resolveTargetConfigs(targetTestCommand(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, []core.TargetConfig{{
+		Name:  "public-api",
+		Paths: []string{"services/api", "libs/shared"},
+	}}, targets)
+}
+
+func TestResolveTargetConfigsFromEnvironment(t *testing.T) {
+	t.Setenv(
+		"TARGETS",
+		"public-api=services/api,libs/shared worker=services/worker",
+	)
+
+	targets, err := resolveTargetConfigs(targetTestCommand(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, []core.TargetConfig{
+		{Name: "public-api", Paths: []string{"services/api", "libs/shared"}},
+		{Name: "worker", Paths: []string{"services/worker"}},
+	}, targets)
+}
+
+func TestTargetFlagReplacesEnvironmentAndFile(t *testing.T) {
+	t.Setenv("TARGETS", "environment=services/worker")
+	viper.Set("targets", []map[string]any{{
+		"name":  "file",
+		"paths": []string{"libs/shared"},
+	}})
+	t.Cleanup(func() { viper.Set("targets", nil) })
+
+	targets, err := resolveTargetConfigs(targetTestCommand(
+		t,
+		"first=services/api",
+		"second=services/worker,libs/shared",
+	))
+
+	require.NoError(t, err)
+	assert.Equal(t, []core.TargetConfig{
+		{Name: "first", Paths: []string{"services/api"}},
+		{Name: "second", Paths: []string{"services/worker", "libs/shared"}},
+	}, targets)
+}
+
+func TestTargetsEnvironmentReplacesFile(t *testing.T) {
+	t.Setenv("TARGETS", "environment=services/worker")
+	viper.Set("targets", []map[string]any{{
+		"name":  "file",
+		"paths": []string{"libs/shared"},
+	}})
+	t.Cleanup(func() { viper.Set("targets", nil) })
+
+	targets, err := resolveTargetConfigs(targetTestCommand(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, []core.TargetConfig{{
+		Name: "environment", Paths: []string{"services/worker"},
+	}}, targets)
+}

--- a/core/commits.go
+++ b/core/commits.go
@@ -188,8 +188,11 @@ func (t *tagger) latestVersion(group DirectoryVersionInfo) (*VersionInfo, error)
 	packageName := group.PackageName()
 	var highest *VersionInfo
 	for _, tag := range t.tags {
-		// The full path match keeps a tag that names a directory path
-		if tag.Package != packageName && tag.Package != group.Directory {
+		matches := tag.Package == packageName
+		for _, alias := range group.TagAliases {
+			matches = matches || tag.Package == alias
+		}
+		if !matches {
 			continue
 		}
 		if highest == nil || tag.Version.Compare(highest.Version) > 0 {

--- a/core/commits.go
+++ b/core/commits.go
@@ -10,6 +10,8 @@ import (
 	"github.com/catalystcommunity/semver-tags/core/semver"
 )
 
+const BreakingChangeType = "BREAKING CHANGE"
+
 // VersionInfo holds one version of one package, and the commit it points at.
 type VersionInfo struct {
 	Package    string
@@ -29,66 +31,174 @@ func (v *VersionInfo) Printable() string {
 	return retVal
 }
 
-// bumpForType gives the version part that each conventional commit type
-// changes. A type that is not in this list does not change the version.
-var bumpForType = map[string]semver.CommitType{
-	"build":    semver.Patch,
-	"chore":    semver.Patch,
-	"ci":       semver.Patch,
-	"docs":     semver.Patch,
-	"feat":     semver.Minor,
-	"fix":      semver.Patch,
-	"perf":     semver.Patch,
-	"refactor": semver.Patch,
-	"revert":   semver.Patch,
-	"style":    semver.Patch,
-	"test":     semver.Patch,
+// defaultPatchTypes gives the commit types that make a patch release when the
+// caller does not configure the patch list.
+var defaultPatchTypes = []string{
+	"build", "chore", "ci", "docs", "fix", "perf", "refactor", "revert", "style", "test",
+}
+
+var defaultMinorTypes = []string{"feat"}
+
+// DefaultPatchTypes gives the commit types that make a patch release by
+// default.
+func DefaultPatchTypes() []string {
+	return slices.Clone(defaultPatchTypes)
+}
+
+// DefaultMinorTypes gives the commit types that make a minor release by
+// default.
+func DefaultMinorTypes() []string {
+	return slices.Clone(defaultMinorTypes)
+}
+
+// DefaultMajorTypes gives the commit types that make a major release by
+// default. A breaking marker makes a major release separately from this list.
+func DefaultMajorTypes() []string {
+	return []string{}
 }
 
 // DefaultAllowedTypes gives the conventional commit types that change a
 // version when the caller does not give a list.
 func DefaultAllowedTypes() []string {
-	types := make([]string, 0, len(bumpForType))
-	for name := range bumpForType {
-		types = append(types, name)
-	}
+	types := append(DefaultPatchTypes(), DefaultMinorTypes()...)
+	types = append(types, BreakingChangeType)
 	sort.Strings(types)
 	return types
 }
 
-// AnalyzeCommitMessage gives the version part that one commit subject changes.
-// A type that is not in allowedTypes changes nothing. An empty allowedTypes
-// means the default list, so a wrong setting can not stop every release.
-func AnalyzeCommitMessage(message string, allowedTypes []string) semver.CommitType {
-	typeAndScope, _, found := strings.Cut(message, ":")
+type bumpRules struct {
+	levels  map[string]semver.CommitType
+	allowed map[string]struct{}
+}
+
+func normalizeTypeList(values []string) []string {
+	var normalized []string
+	for _, value := range values {
+		for _, member := range strings.Split(value, ",") {
+			member = strings.TrimSpace(member)
+			if member == "" {
+				continue
+			}
+			if strings.EqualFold(member, BreakingChangeType) ||
+				strings.EqualFold(member, "BREAKING-CHANGE") {
+				member = BreakingChangeType
+			} else {
+				member = strings.ToLower(member)
+			}
+			if !slices.Contains(normalized, member) {
+				normalized = append(normalized, member)
+			}
+		}
+	}
+	return normalized
+}
+
+func newBumpRules(config Config) (bumpRules, error) {
+	patchTypes := normalizeTypeList(config.PatchTypes)
+	if len(patchTypes) == 0 {
+		patchTypes = DefaultPatchTypes()
+	}
+	minorTypes := normalizeTypeList(config.MinorTypes)
+	if len(minorTypes) == 0 {
+		minorTypes = DefaultMinorTypes()
+	}
+	majorTypes := normalizeTypeList(config.MajorTypes)
+
+	if slices.Contains(minorTypes, "fix") || slices.Contains(majorTypes, "fix") {
+		return bumpRules{}, fmt.Errorf("commit type %q must make a patch release", "fix")
+	}
+	if slices.Contains(patchTypes, "feat") || slices.Contains(majorTypes, "feat") {
+		return bumpRules{}, fmt.Errorf("commit type %q must make a minor release", "feat")
+	}
+	if !slices.Contains(patchTypes, "fix") {
+		patchTypes = append(patchTypes, "fix")
+	}
+	if !slices.Contains(minorTypes, "feat") {
+		minorTypes = append(minorTypes, "feat")
+	}
+
+	rules := bumpRules{levels: map[string]semver.CommitType{}}
+	addTypes := func(values []string, level semver.CommitType) error {
+		for _, value := range values {
+			if value == BreakingChangeType {
+				return fmt.Errorf("%q is a breaking marker and cannot be a configured commit type", value)
+			}
+			if previous, found := rules.levels[value]; found && previous != level {
+				return fmt.Errorf("commit type %q is configured for more than one version level", value)
+			}
+			rules.levels[value] = level
+		}
+		return nil
+	}
+	if err := addTypes(patchTypes, semver.Patch); err != nil {
+		return bumpRules{}, err
+	}
+	if err := addTypes(minorTypes, semver.Minor); err != nil {
+		return bumpRules{}, err
+	}
+	if err := addTypes(majorTypes, semver.Major); err != nil {
+		return bumpRules{}, err
+	}
+
+	allowedTypes := normalizeTypeList(config.AllowedTypes)
+	if len(allowedTypes) == 0 {
+		for value := range rules.levels {
+			allowedTypes = append(allowedTypes, value)
+		}
+		allowedTypes = append(allowedTypes, BreakingChangeType)
+	}
+	rules.allowed = make(map[string]struct{}, len(allowedTypes))
+	for _, value := range allowedTypes {
+		rules.allowed[value] = struct{}{}
+	}
+	return rules, nil
+}
+
+func hasBreakingChange(message string) bool {
+	subject := strings.SplitN(message, "\n", 2)[0]
+	typeAndScope, _, found := strings.Cut(subject, ":")
+	if found && strings.HasSuffix(strings.TrimSpace(typeAndScope), "!") {
+		return true
+	}
+	for _, line := range strings.Split(message, "\n") {
+		if strings.HasPrefix(line, "BREAKING CHANGE: ") ||
+			strings.HasPrefix(line, "BREAKING-CHANGE: ") {
+			return true
+		}
+	}
+	return false
+}
+
+func analyzeCommitMessage(message string, rules bumpRules) semver.CommitType {
+	if hasBreakingChange(message) {
+		if _, allowed := rules.allowed[BreakingChangeType]; !allowed {
+			return semver.NotConventional
+		}
+		return semver.Major
+	}
+
+	subject := strings.SplitN(message, "\n", 2)[0]
+	typeAndScope, _, found := strings.Cut(subject, ":")
 	if !found {
 		return semver.NotConventional
 	}
-
-	// A breaking change is major whatever the allowed types are
-	if strings.TrimSpace(typeAndScope) == "BREAKING CHANGE" {
-		return semver.Major
-	}
-
-	breaking := strings.HasSuffix(typeAndScope, "!")
-	commitType, _, _ := strings.Cut(strings.TrimSuffix(typeAndScope, "!"), "(")
-	commitType = strings.TrimSpace(strings.TrimSuffix(commitType, "!"))
-
-	bump, known := bumpForType[commitType]
-	if !known {
+	commitType, _, _ := strings.Cut(strings.TrimSpace(typeAndScope), "(")
+	commitType = strings.ToLower(strings.TrimSpace(commitType))
+	if _, allowed := rules.allowed[commitType]; !allowed {
 		return semver.NotConventional
 	}
-	if len(allowedTypes) == 0 {
-		allowedTypes = DefaultAllowedTypes()
-	}
-	if !slices.Contains(allowedTypes, commitType) {
+	return rules.levels[commitType]
+}
+
+// AnalyzeCommitMessage gives the version part that one commit subject changes.
+// A type that is not in allowedTypes changes nothing. An empty allowedTypes
+// permits every default type and a breaking marker.
+func AnalyzeCommitMessage(message string, allowedTypes []string) semver.CommitType {
+	rules, err := newBumpRules(Config{AllowedTypes: allowedTypes})
+	if err != nil {
 		return semver.NotConventional
 	}
-
-	if breaking {
-		return semver.Major
-	}
-	return bump
+	return analyzeCommitMessage(message, rules)
 }
 
 // ParseVersionInfo reads one "tag,commit" line into a version. The tag is
@@ -146,6 +256,7 @@ func ParseVersionInfo(line string) (*VersionInfo, error) {
 // only one time for all of the directory groups.
 type tagger struct {
 	config     Config
+	rules      bumpRules
 	head       string
 	tags       []*VersionInfo
 	tagsLoaded bool
@@ -231,16 +342,16 @@ func (t *tagger) analyzeCommits(group *DirectoryVersionInfo) error {
 		group.LastVersion.Package,
 		commitPaths,
 	))
-	subjects, err := commitSubjects(group.LastVersion.CommitHash, commitPaths)
+	commits, err := commitMessages(group.LastVersion.CommitHash, commitPaths)
 	if err != nil {
 		return err
 	}
 
 	highest := semver.NotConventional
 	releaseNotes := []string{}
-	for _, subject := range subjects {
-		logging.Log.Info(fmt.Sprintf("Analyzing Commit: %s", subject))
-		commitType := AnalyzeCommitMessage(subject, t.config.AllowedTypes)
+	for _, commit := range commits {
+		logging.Log.Info(fmt.Sprintf("Analyzing Commit: %s", commit.Subject))
+		commitType := analyzeCommitMessage(commit.Message, t.rules)
 		if commitType > highest {
 			highest = commitType
 		}
@@ -254,7 +365,7 @@ func (t *tagger) analyzeCommits(group *DirectoryVersionInfo) error {
 		case semver.Major:
 			logging.Log.Info("Found Major commit")
 		}
-		releaseNotes = append(releaseNotes, subject)
+		releaseNotes = append(releaseNotes, commit.Subject)
 	}
 
 	// If no change is needed, this will be a noOp

--- a/core/commits_test.go
+++ b/core/commits_test.go
@@ -46,13 +46,16 @@ func TestAnalyzeCommitMessageHonorsAllowedTypes(t *testing.T) {
 	assert.Equal(t, semver.NotConventional, AnalyzeCommitMessage("ci: change it", allowed))
 }
 
-// A breaking change is major even when its type is not allowed, because
-// dropping it would hide an incompatible change.
-func TestAnalyzeCommitMessageAlwaysTakesBreakingChange(t *testing.T) {
+func TestAnalyzeCommitMessageFiltersBreakingChanges(t *testing.T) {
+	assert.Equal(
+		t,
+		semver.NotConventional,
+		AnalyzeCommitMessage("BREAKING CHANGE: break it", []string{"fix"}),
+	)
 	assert.Equal(
 		t,
 		semver.Major,
-		AnalyzeCommitMessage("BREAKING CHANGE: break it", []string{"fix"}),
+		AnalyzeCommitMessage("BREAKING CHANGE: break it", []string{BreakingChangeType}),
 	)
 }
 
@@ -66,9 +69,84 @@ func TestDefaultAllowedTypesIsSortedAndComplete(t *testing.T) {
 	types := DefaultAllowedTypes()
 
 	assert.Equal(t, []string{
-		"build", "chore", "ci", "docs", "feat",
+		BreakingChangeType, "build", "chore", "ci", "docs", "feat",
 		"fix", "perf", "refactor", "revert", "style", "test",
 	}, types)
+}
+
+func TestConfiguredCommitTypesCanUseEveryBumpLevel(t *testing.T) {
+	rules, err := newBumpRules(Config{
+		PatchTypes: []string{"holiday"},
+		MinorTypes: []string{"meatball"},
+		MajorTypes: []string{"earthquake"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, semver.Patch, analyzeCommitMessage("holiday: celebrate", rules))
+	assert.Equal(t, semver.Minor, analyzeCommitMessage("meatball: add sauce", rules))
+	assert.Equal(t, semver.Major, analyzeCommitMessage("earthquake: move it", rules))
+	assert.Equal(t, semver.Patch, analyzeCommitMessage("fix: repair it", rules))
+	assert.Equal(t, semver.Minor, analyzeCommitMessage("feat: add it", rules))
+}
+
+func TestConfiguredCommitTypesAcceptCommaSeparatedValues(t *testing.T) {
+	rules, err := newBumpRules(Config{PatchTypes: []string{"holiday,meatball"}})
+	require.NoError(t, err)
+
+	assert.Equal(t, semver.Patch, analyzeCommitMessage("holiday: celebrate", rules))
+	assert.Equal(t, semver.Patch, analyzeCommitMessage("meatball: add sauce", rules))
+}
+
+func TestAllowedTypesFilterConfiguredTypes(t *testing.T) {
+	rules, err := newBumpRules(Config{
+		PatchTypes:   []string{"holiday", "meatball"},
+		AllowedTypes: []string{"holiday"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, semver.Patch, analyzeCommitMessage("holiday: celebrate", rules))
+	assert.Equal(t, semver.NotConventional, analyzeCommitMessage("meatball: add sauce", rules))
+	assert.Equal(t, semver.NotConventional, analyzeCommitMessage("fix: repair it", rules))
+}
+
+func TestBreakingChangeAllowedTypeAcceptsHyphenatedAlias(t *testing.T) {
+	rules, err := newBumpRules(Config{AllowedTypes: []string{"BREAKING-CHANGE"}})
+	require.NoError(t, err)
+
+	assert.Equal(t, semver.Major, analyzeCommitMessage("fix!: break it", rules))
+}
+
+func TestFixAndFeatBumpLevelsCannotChange(t *testing.T) {
+	_, err := newBumpRules(Config{MinorTypes: []string{"fix"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must make a patch release")
+
+	_, err = newBumpRules(Config{PatchTypes: []string{"feat"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must make a minor release")
+}
+
+func TestOneTypeCannotUseTwoBumpLevels(t *testing.T) {
+	_, err := newBumpRules(Config{
+		PatchTypes: []string{"holiday"},
+		MinorTypes: []string{"holiday"},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "more than one version level")
+}
+
+func TestBreakingChangeFooterMakesAMajorBump(t *testing.T) {
+	rules, err := newBumpRules(Config{})
+	require.NoError(t, err)
+
+	message := "holiday: change everything\n\nBREAKING CHANGE: old clients cannot connect"
+	assert.Equal(t, semver.Major, analyzeCommitMessage(message, rules))
+	assert.Equal(
+		t,
+		semver.Major,
+		analyzeCommitMessage("holiday!: change everything", rules),
+	)
 }
 
 func TestParseVersionInfo(t *testing.T) {

--- a/core/directories.go
+++ b/core/directories.go
@@ -5,25 +5,39 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
-// DirectoryVersionInfo holds one tag group. Directory is the first directory
-// of the group, and it names the tag. Directories holds the git paths of every
-// directory in the group, because a commit in any of them changes this tag.
+// TargetConfig separates the public release name from the paths that affect
+// the release.
+type TargetConfig struct {
+	Name  string   `mapstructure:"name" yaml:"name"`
+	Paths []string `mapstructure:"paths" yaml:"paths"`
+}
+
+// DirectoryVersionInfo holds one release target. Package is its public name.
+// Directories holds the Git paths that affect it. Directory and TagAliases
+// keep the legacy directory-name behavior.
 type DirectoryVersionInfo struct {
 	Directory    string
 	Directories  []string
+	Package      string
+	TagAliases   []string
 	FullPath     string
 	LastVersion  *VersionInfo
 	NextVersion  *VersionInfo
 	ReleaseNotes []string
 	UseRoot      bool
+	RootRelative bool
 }
 
-// PackageName gives the package part of the tag for this group. It is the last
-// path element of the first directory, and it is empty for whole repo mode.
+// PackageName gives the package part of the tag. Parsed targets store this
+// value explicitly. The fallback keeps callers that construct legacy values.
 func (d *DirectoryVersionInfo) PackageName() string {
+	if d.Package != "" {
+		return d.Package
+	}
 	trimmed := strings.TrimRight(d.Directory, "/")
 	if trimmed == "" {
 		return ""
@@ -36,6 +50,17 @@ func (d *DirectoryVersionInfo) PackageName() string {
 // repo mode the group has no directories, so the full path is the limit.
 func (d *DirectoryVersionInfo) CommitPaths() []string {
 	if len(d.Directories) > 0 {
+		if d.RootRelative {
+			paths := make([]string, 0, len(d.Directories))
+			for _, directory := range d.Directories {
+				if directory == "." {
+					paths = append(paths, ":(top)")
+					continue
+				}
+				paths = append(paths, ":(top,literal)"+directory)
+			}
+			return paths
+		}
 		return d.Directories
 	}
 	return []string{strings.TrimRight(d.FullPath, "/")}
@@ -43,6 +68,9 @@ func (d *DirectoryVersionInfo) CommitPaths() []string {
 
 func (d *DirectoryVersionInfo) Printable() string {
 	retVal := "DirectoryVersionInfo:\n"
+	if d.RootRelative {
+		retVal += fmt.Sprintf("Package: %s\n", d.PackageName())
+	}
 	retVal += fmt.Sprintf("Directory: %s\n", d.Directory)
 	retVal += fmt.Sprintf("Directories: %v\n", d.Directories)
 	retVal += fmt.Sprintf("FullPath: %s\n", d.FullPath)
@@ -71,6 +99,29 @@ func splitDirectoryGroup(value string) []string {
 		members = append(members, part)
 	}
 	return members
+}
+
+// ParseTargetSpecifications reads the compact form that the command-line and
+// environment interfaces use. A comma separates paths. This form does not
+// have an escaping syntax.
+func ParseTargetSpecifications(values []string) ([]TargetConfig, error) {
+	targets := make([]TargetConfig, 0, len(values))
+	for _, value := range values {
+		name, pathsText, found := strings.Cut(value, "=")
+		if !found {
+			return nil, fmt.Errorf("target %q must have the form name=path[,path...]", value)
+		}
+
+		paths := strings.Split(pathsText, ",")
+		for index := range paths {
+			paths[index] = strings.TrimSpace(paths[index])
+		}
+		targets = append(targets, TargetConfig{
+			Name:  strings.TrimSpace(name),
+			Paths: paths,
+		})
+	}
+	return targets, nil
 }
 
 // appendNewPath adds a path only when the list does not hold it, because a
@@ -125,7 +176,76 @@ func newDirectoryGroup(
 		}
 		group.Directories = appendNewPath(group.Directories, commitPath)
 	}
+	group.Package = group.PackageName()
+	if group.Directory != group.Package {
+		group.TagAliases = []string{group.Directory}
+	}
 
+	return group, nil
+}
+
+var targetNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+func validateTargetName(name string) error {
+	if name == "" {
+		return fmt.Errorf("target name must not be empty")
+	}
+	if !targetNamePattern.MatchString(name) ||
+		strings.Contains(name, "..") ||
+		strings.HasSuffix(name, ".") ||
+		strings.HasSuffix(strings.ToLower(name), ".lock") {
+		return fmt.Errorf(
+			"target name %q is not a safe Git tag prefix; use letters, digits, dots, underscores, and hyphens",
+			name,
+		)
+	}
+	if _, err := runGit("check-ref-format", "refs/tags/"+name+"/v0.0.0"); err != nil {
+		return fmt.Errorf("target name %q is not a valid Git tag prefix", name)
+	}
+	return nil
+}
+
+// normalizeTargetPath makes one named-target path relative to the Git root.
+// It does not check if the path exists because deleted paths can affect a
+// release.
+func normalizeTargetPath(value string) (string, error) {
+	if strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("target path must not be empty")
+	}
+	if strings.Contains(value, `\`) {
+		return "", fmt.Errorf("target path %q must use forward slashes", value)
+	}
+	if filepath.IsAbs(value) || path.IsAbs(value) {
+		return "", fmt.Errorf("target path %q must be relative to the Git root", value)
+	}
+
+	normalized := path.Clean(value)
+	if normalized == ".." || strings.HasPrefix(normalized, "../") {
+		return "", fmt.Errorf("target path %q must stay in the Git repository", value)
+	}
+	return normalized, nil
+}
+
+func newNamedTarget(target TargetConfig, gitRoot string) (DirectoryVersionInfo, error) {
+	group := DirectoryVersionInfo{
+		Package:      target.Name,
+		FullPath:     gitRoot,
+		RootRelative: true,
+	}
+	if err := validateTargetName(target.Name); err != nil {
+		return group, err
+	}
+	if len(target.Paths) == 0 {
+		return group, fmt.Errorf("target %q must have at least one path", target.Name)
+	}
+
+	for _, value := range target.Paths {
+		normalized, err := normalizeTargetPath(value)
+		if err != nil {
+			return group, fmt.Errorf("target %q: %w", target.Name, err)
+		}
+		group.Directories = appendNewPath(group.Directories, normalized)
+	}
 	return group, nil
 }
 
@@ -182,6 +302,45 @@ func ParseDirectoryGroups(
 		if err := addGroup(value, splitDirectoryGroup(value)); err != nil {
 			return nil, err
 		}
+	}
+
+	return groups, nil
+}
+
+// ParseReleaseTargets makes every release target for one run. Legacy
+// directories keep their current order and behavior. Named targets follow
+// all legacy targets in their configured order.
+func ParseReleaseTargets(
+	directories []string,
+	dirGroups []string,
+	targets []TargetConfig,
+	gitRoot string,
+) ([]DirectoryVersionInfo, error) {
+	groups, err := ParseDirectoryGroups(directories, dirGroups, gitRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	groupForPackage := make(map[string]string, len(groups)+len(targets))
+	for _, group := range groups {
+		groupForPackage[group.PackageName()] = "a legacy directory or directory group"
+	}
+
+	for index, target := range targets {
+		group, err := newNamedTarget(target, gitRoot)
+		if err != nil {
+			return nil, err
+		}
+		if previous, found := groupForPackage[group.PackageName()]; found {
+			return nil, fmt.Errorf(
+				"%s and target %q at position %d both tag the package %q",
+				previous, target.Name, index+1, group.PackageName(),
+			)
+		}
+		groupForPackage[group.PackageName()] = fmt.Sprintf(
+			"target %q at position %d", target.Name, index+1,
+		)
+		groups = append(groups, group)
 	}
 
 	return groups, nil

--- a/core/git.go
+++ b/core/git.go
@@ -101,16 +101,32 @@ func repositoryTagLines() ([]string, error) {
 	return lines, nil
 }
 
-// commitSubjects gives the subject of each commit after the given commit that
-// changed one of the given paths.
-func commitSubjects(afterCommit string, paths []string) ([]string, error) {
-	args := []string{"log", "--pretty=format:%s", fmt.Sprintf("%s..HEAD", afterCommit), "--"}
+type commitMessage struct {
+	Subject string
+	Message string
+}
+
+// commitMessages gives the subject and full message of each commit after the
+// given commit that changed one of the given paths.
+func commitMessages(afterCommit string, paths []string) ([]commitMessage, error) {
+	args := []string{"log", "-z", "--pretty=format:%s%x00%B", fmt.Sprintf("%s..HEAD", afterCommit), "--"}
 	args = append(args, paths...)
-	subjects, err := gitLines(args...)
+	output, err := runGit(args...)
 	if err != nil {
 		return nil, fmt.Errorf("can not get git commits: %w", err)
 	}
-	return subjects, nil
+
+	parts := strings.Split(output, "\x00")
+	commits := make([]commitMessage, 0, len(parts)/2)
+	for index := 0; index+1 < len(parts); index += 2 {
+		subject := strings.TrimSuffix(parts[index], "\n")
+		message := strings.TrimSuffix(parts[index+1], "\n")
+		if subject == "" && message == "" {
+			continue
+		}
+		commits = append(commits, commitMessage{Subject: subject, Message: message})
+	}
+	return commits, nil
 }
 
 // createTag makes one local tag at HEAD.
@@ -121,10 +137,24 @@ func createTag(tag string) error {
 	return nil
 }
 
+// updateTag makes a local tag at HEAD or moves an existing local tag to HEAD.
+func updateTag(tag string) error {
+	if _, err := runGit("tag", "--force", tag); err != nil {
+		return fmt.Errorf("error updating tag: %w", err)
+	}
+	return nil
+}
+
 // pushTags sends the new tags to the remote. An empty branch pushes only the
 // tags, which is what a job that checked out a commit instead of a branch
 // needs. The atomic option makes the remote take all of the tags or none.
-func pushTags(remote string, branch string, atomic bool, tags []string) error {
+func pushTags(
+	remote string,
+	branch string,
+	atomic bool,
+	tags []string,
+	forceTags []string,
+) error {
 	args := []string{"push"}
 	if atomic {
 		args = append(args, "--atomic")
@@ -134,6 +164,9 @@ func pushTags(remote string, branch string, atomic bool, tags []string) error {
 		args = append(args, branch)
 	}
 	args = append(args, tags...)
+	for _, tag := range forceTags {
+		args = append(args, "+refs/tags/"+tag+":refs/tags/"+tag)
+	}
 
 	if _, err := runGit(args...); err != nil {
 		return fmt.Errorf("error pushing tags: %w", err)

--- a/core/outputs.go
+++ b/core/outputs.go
@@ -48,6 +48,19 @@ func tagFor(version *VersionInfo) string {
 	return version.Package + "/" + version.Version.FormattedString()
 }
 
+// shortTagsFor gives the mutable major and minor tags for one full release
+// tag. These tags point to the same commit as the full release tag.
+func shortTagsFor(version *VersionInfo) []string {
+	prefix := ""
+	if version.Package != "" {
+		prefix = version.Package + "/"
+	}
+	return []string{
+		fmt.Sprintf("%sv%d.%d", prefix, version.Version.Major, version.Version.Minor),
+		fmt.Sprintf("%sv%d", prefix, version.Version.Major),
+	}
+}
+
 // releaseNotesJson makes a JSON object with the notes of each package. It
 // keeps the order of the groups, which a JSON object of a Go map would not.
 func releaseNotesJson(results []DirectoryVersionInfo) (string, error) {

--- a/core/outputs_test.go
+++ b/core/outputs_test.go
@@ -53,6 +53,20 @@ func TestGenerateOutputsForOneGroup(t *testing.T) {
 	assert.Equal(t, "feat: a thing", outputs.NewReleaseNotes)
 }
 
+func TestShortTagsForPackageVersion(t *testing.T) {
+	info, err := ParseVersionInfo("api/v1.3.7,hash")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"api/v1.3", "api/v1"}, shortTagsFor(info))
+}
+
+func TestShortTagsForWholeRepositoryVersion(t *testing.T) {
+	info, err := ParseVersionInfo("v1.3.7,hash")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"v1.3", "v1"}, shortTagsFor(info))
+}
+
 func TestGenerateOutputsJoinsGroupsInOrder(t *testing.T) {
 	results := []DirectoryVersionInfo{
 		group("api", "v1.0.0", "v1.1.0", []string{"feat: a thing"}),

--- a/core/tagging.go
+++ b/core/tagging.go
@@ -21,6 +21,7 @@ type Config struct {
 	AllowedTypes     []string
 	Directories      []string
 	DirGroups        []string
+	Targets          []TargetConfig
 }
 
 // DoTagging works out the next version of each directory group, makes the
@@ -37,18 +38,18 @@ func DoTagging(config Config) error {
 		return err
 	}
 
-	head, err := headCommit()
-	if err != nil {
-		return err
-	}
-
-	results, err := ParseDirectoryGroups(config.Directories, config.DirGroups, gitRoot)
+	results, err := ParseReleaseTargets(config.Directories, config.DirGroups, config.Targets, gitRoot)
 	if err != nil {
 		return err
 	}
 	// With no directory given, the whole repo is one unnamed package
 	if len(results) == 0 {
 		results = append(results, DirectoryVersionInfo{FullPath: gitRoot})
+	}
+
+	head, err := headCommit()
+	if err != nil {
+		return err
 	}
 
 	run := &tagger{config: config, head: head}

--- a/core/tagging.go
+++ b/core/tagging.go
@@ -4,29 +4,54 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/catalystcommunity/app-utils-go/logging"
+	"github.com/sirupsen/logrus"
 )
+
+const shortVersionWarning = "WARNING: Short version tags will become the default in the next major version. " +
+	"Use --short-versions to enable them now or --skip-short-versions to keep the current behavior " +
+	"without this warning. --skip-short-versions will be removed after the next major version."
 
 // Config holds every setting of one tagging run.
 type Config struct {
-	DryRun           bool
-	GithubAction     bool
-	OutputJson       bool
-	Atomic           bool
-	PreReleaseString string
-	BuildString      string
-	Remote           string
-	Branch           string
-	AllowedTypes     []string
-	Directories      []string
-	DirGroups        []string
-	Targets          []TargetConfig
+	DryRun            bool
+	GithubAction      bool
+	OutputJson        bool
+	Atomic            bool
+	PreReleaseString  string
+	BuildString       string
+	Remote            string
+	Branch            string
+	AllowedTypes      []string
+	PatchTypes        []string
+	MinorTypes        []string
+	MajorTypes        []string
+	ShortVersions     bool
+	SkipShortVersions bool
+	Directories       []string
+	DirGroups         []string
+	Targets           []TargetConfig
 }
 
 // DoTagging works out the next version of each directory group, makes the
 // tags, and writes the outputs.
 func DoTagging(config Config) error {
+	if config.ShortVersions && config.SkipShortVersions {
+		return errors.New("short_versions and skip_short_versions cannot both be true")
+	}
+	if !config.ShortVersions && !config.SkipShortVersions &&
+		logging.Log.IsLevelEnabled(logrus.WarnLevel) {
+		if _, err := fmt.Fprintln(os.Stdout, shortVersionWarning); err != nil {
+			return fmt.Errorf("can not write the short-version migration warning: %w", err)
+		}
+	}
+	rules, err := newBumpRules(config)
+	if err != nil {
+		return err
+	}
+
 	// Make sure we're in a git repo with a git command or this is pointless
 	if !IsGitRepo() {
 		return errors.New("current directory is not a git repo, nothing to do")
@@ -52,7 +77,7 @@ func DoTagging(config Config) error {
 		return err
 	}
 
-	run := &tagger{config: config, head: head}
+	run := &tagger{config: config, rules: rules, head: head}
 	for idx := range results {
 		// Get the latest tag and hash that applies for this directory
 		results[idx].LastVersion, err = run.latestVersion(results[idx])
@@ -68,6 +93,7 @@ func DoTagging(config Config) error {
 
 	// Process what tags we should be making
 	var newTags []string
+	var shortTags []string
 	for _, result := range results {
 		if result.NextVersion == nil ||
 			result.LastVersion.Version.FormattedString() == result.NextVersion.Version.FormattedString() {
@@ -89,6 +115,20 @@ func DoTagging(config Config) error {
 			}
 		}
 		newTags = append(newTags, tag)
+
+		if config.ShortVersions {
+			for _, shortTag := range shortTagsFor(result.NextVersion) {
+				if config.DryRun {
+					logging.Log.Info(fmt.Sprintf("We would be updating a short version tag: %s", shortTag))
+				} else {
+					logging.Log.Info(fmt.Sprintf("Updating short version tag: %s", shortTag))
+					if err := updateTag(shortTag); err != nil {
+						return err
+					}
+				}
+				shortTags = append(shortTags, shortTag)
+			}
+		}
 	}
 
 	outputs, err := GenerateOutputs(results, config.DryRun)
@@ -100,7 +140,7 @@ func DoTagging(config Config) error {
 	// All tags should be there, so push! This prevents tags being pushed if
 	// there were errors. Ex. cmd: git push --atomic origin main tagOne tagTwo
 	if !config.DryRun && len(newTags) > 0 {
-		if err := pushTags(config.Remote, config.Branch, config.Atomic, newTags); err != nil {
+		if err := pushTags(config.Remote, config.Branch, config.Atomic, newTags, shortTags); err != nil {
 			return err
 		}
 	}

--- a/core/tagging_test.go
+++ b/core/tagging_test.go
@@ -107,6 +107,17 @@ func (s *TaggingSuite) tagDryRun(directories []string, dirGroups []string) Outpu
 	})
 }
 
+func (s *TaggingSuite) targetDryRun(targets []TargetConfig) Outputs {
+	return s.runTagging(Config{
+		DryRun:     true,
+		OutputJson: true,
+		Atomic:     true,
+		Remote:     "origin",
+		Branch:     "main",
+		Targets:    targets,
+	})
+}
+
 func (s *TaggingSuite) runTagging(config Config) Outputs {
 	previousStdout := os.Stdout
 	capturePath := filepath.Join(s.T().TempDir(), "outputs.json")
@@ -202,6 +213,207 @@ func (s *TaggingSuite) TestWholeRepositoryKeepsOneUnnamedTag() {
 	assert.Equal(s.T(), "", outputs.ReleasePackage)
 }
 
+func (s *TaggingSuite) TestNamedTargetUsesItsNameWithOnePath() {
+	s.write("services/api/file.txt", "api change")
+	s.commit("fix: api change")
+
+	outputs := s.targetDryRun([]TargetConfig{{
+		Name:  "public-api",
+		Paths: []string{"services/api"},
+	}})
+
+	assert.Equal(s.T(), "public-api/v0.1.1", outputs.NewReleaseGitTag)
+	assert.Equal(s.T(), "public-api", outputs.ReleasePackage)
+	assert.Contains(s.T(), outputs.NewReleaseNotesJson, `"package_public-api"`)
+}
+
+func (s *TaggingSuite) TestNamedTargetUsesEveryPath() {
+	s.write("libs/shared/file.txt", "shared change")
+	s.commit("feat: shared change")
+
+	outputs := s.targetDryRun([]TargetConfig{{
+		Name:  "public-api",
+		Paths: []string{"services/api", "libs/shared"},
+	}})
+
+	assert.Equal(s.T(), "public-api/v0.2.0", outputs.NewReleaseGitTag)
+	assert.Equal(s.T(), "true", outputs.NewReleasePublished)
+}
+
+func (s *TaggingSuite) TestNamedTargetsCanShareAPathAndKeepOrder() {
+	s.write("libs/shared/file.txt", "shared change")
+	s.commit("fix: shared change")
+
+	outputs := s.targetDryRun([]TargetConfig{
+		{Name: "worker-public", Paths: []string{"services/worker", "libs/shared"}},
+		{Name: "api-public", Paths: []string{"services/api", "libs/shared"}},
+	})
+
+	assert.Equal(s.T(), "worker-public,api-public", outputs.ReleasePackage)
+	assert.Equal(
+		s.T(),
+		"worker-public/v0.1.1,api-public/v0.1.1",
+		outputs.NewReleaseGitTag,
+	)
+}
+
+func (s *TaggingSuite) TestLegacyFormsRunBeforeNamedTargets() {
+	s.write("libs/shared/file.txt", "shared change")
+	s.commit("fix: shared change")
+
+	outputs := s.runTagging(Config{
+		DryRun:      true,
+		OutputJson:  true,
+		Directories: []string{"libs/shared"},
+		DirGroups:   []string{"services/api,libs/shared"},
+		Targets: []TargetConfig{{
+			Name:  "worker-public",
+			Paths: []string{"services/worker", "libs/shared"},
+		}},
+	})
+
+	assert.Equal(s.T(), "shared,api,worker-public", outputs.ReleasePackage)
+}
+
+// This configuration uses only interfaces that v0.5.0 supports. Its output
+// values are a compatibility contract for named-target changes.
+func (s *TaggingSuite) TestLegacyV050ConfigurationKeepsItsOutputs() {
+	s.write("libs/shared/file.txt", "shared change")
+	s.commit("fix: shared change")
+
+	outputs := s.runTagging(Config{
+		DryRun:      true,
+		OutputJson:  true,
+		Directories: []string{"services/worker"},
+		DirGroups:   []string{"services/api,libs/shared"},
+	})
+
+	assert.Equal(s.T(), "false,true", outputs.NewReleasePublished)
+	assert.Equal(s.T(), "worker,api", outputs.ReleasePackage)
+	assert.Equal(s.T(), "worker/v2.0.0,api/v1.0.1", outputs.NewReleaseGitTag)
+	assert.Equal(s.T(), "worker/v2.0.0,api/v1.0.0", outputs.LastReleaseGitTag)
+	assert.Equal(s.T(), ",\nfix: shared change", outputs.NewReleaseNotes)
+}
+
+func (s *TaggingSuite) TestChangeOutsideNamedTargetKeepsUnchangedOutputs() {
+	s.git("tag", "public-api/v3.2.1")
+	s.write("services/worker/file.txt", "worker change")
+	s.commit("fix: worker change")
+
+	outputs := s.runTagging(Config{
+		OutputJson: true,
+		Targets: []TargetConfig{{
+			Name:  "public-api",
+			Paths: []string{"services/api"},
+		}},
+	})
+
+	assert.Equal(s.T(), "false", outputs.NewReleasePublished)
+	assert.Equal(s.T(), "public-api/v3.2.1", outputs.LastReleaseGitTag)
+	assert.Equal(s.T(), outputs.LastReleaseGitTag, outputs.NewReleaseGitTag)
+	command := exec.Command("git", "tag", "--list", "public-api/v3.2.2")
+	command.Dir = s.repoDir
+	content, err := command.Output()
+	require.NoError(s.T(), err)
+	assert.Empty(s.T(), string(content))
+}
+
+func (s *TaggingSuite) TestNamedTargetReadsOnlyItsExplicitTagName() {
+	s.git("tag", "services/api/v9.0.0")
+	s.write("services/api/file.txt", "api change")
+	s.commit("fix: api change")
+
+	outputs := s.targetDryRun([]TargetConfig{{
+		Name:  "public-api",
+		Paths: []string{"services/api"},
+	}})
+
+	assert.Equal(s.T(), "public-api/v0.1.0", outputs.LastReleaseGitTag)
+	assert.Equal(s.T(), "public-api/v0.1.1", outputs.NewReleaseGitTag)
+}
+
+func (s *TaggingSuite) TestLegacyTargetStillReadsAFullPathTag() {
+	s.git("tag", "services/api/v4.0.0")
+	s.write("services/api/file.txt", "api change")
+	s.commit("fix: api change")
+
+	outputs := s.tagDryRun([]string{"services/api"}, nil)
+
+	assert.Equal(s.T(), "api/v4.0.0", outputs.LastReleaseGitTag)
+	assert.Equal(s.T(), "api/v4.0.1", outputs.NewReleaseGitTag)
+}
+
+func (s *TaggingSuite) TestNamedPathsAreRelativeToTheGitRoot() {
+	s.write("services/api/file.txt", "api change")
+	s.commit("fix: api change")
+	require.NoError(s.T(), os.Chdir(filepath.Join(s.repoDir, "libs")))
+
+	outputs := s.targetDryRun([]TargetConfig{{
+		Name:  "public-api",
+		Paths: []string{"services/api"},
+	}})
+
+	assert.Equal(s.T(), "public-api/v0.1.1", outputs.NewReleaseGitTag)
+}
+
+func (s *TaggingSuite) TestNamedTargetCanUseAFilePath() {
+	s.write("README.md", "readme change")
+	s.commit("docs: update readme")
+
+	outputs := s.targetDryRun([]TargetConfig{{
+		Name:  "documentation",
+		Paths: []string{"README.md"},
+	}})
+
+	assert.Equal(s.T(), "documentation/v0.1.1", outputs.NewReleaseGitTag)
+}
+
+func (s *TaggingSuite) TestNamedTargetDotPathUsesTheWholeRepository() {
+	s.write("services/worker/file.txt", "worker change")
+	s.commit("fix: worker change")
+
+	outputs := s.targetDryRun([]TargetConfig{{
+		Name:  "all-source",
+		Paths: []string{"."},
+	}})
+
+	assert.Equal(s.T(), "all-source/v0.1.1", outputs.NewReleaseGitTag)
+}
+
+func (s *TaggingSuite) TestMultipleNamedTagsUseOneAtomicPush() {
+	remoteDir := filepath.Join(s.T().TempDir(), "remote.git")
+	command := exec.Command("git", "init", "-q", "--bare", remoteDir)
+	require.NoError(s.T(), command.Run())
+	s.git("remote", "add", "origin", remoteDir)
+
+	s.write("services/api/file.txt", "api change")
+	s.write("services/worker/file.txt", "worker change")
+	s.commit("fix: service change")
+
+	outputs := s.runTagging(Config{
+		OutputJson: true,
+		Atomic:     true,
+		Remote:     "origin",
+		Branch:     "",
+		Targets: []TargetConfig{
+			{Name: "public-api", Paths: []string{"services/api"}},
+			{Name: "public-worker", Paths: []string{"services/worker"}},
+		},
+	})
+
+	assert.Equal(
+		s.T(),
+		"public-api/v0.1.1,public-worker/v0.1.1",
+		outputs.NewReleaseGitTag,
+	)
+	for _, tag := range []string{"public-api/v0.1.1", "public-worker/v0.1.1"} {
+		check := exec.Command("git", "--git-dir", remoteDir, "rev-parse", "refs/tags/"+tag)
+		content, err := check.Output()
+		require.NoError(s.T(), err)
+		assert.Equal(s.T(), s.headCommit(), string(content[:40]))
+	}
+}
+
 // A --directories value keeps its old meaning. It is one literal path, even
 // when it holds a comma, and it never becomes a group.
 func (s *TaggingSuite) TestDirectoriesValueStaysOneLiteralPath() {
@@ -276,6 +488,99 @@ func (s *TaggingSuite) TestEmptyGroupIsAnError() {
 
 	require.Error(s.T(), err)
 	assert.Contains(s.T(), err.Error(), "does not name a directory")
+}
+
+func (s *TaggingSuite) TestDuplicateNamedTargetsAreAnError() {
+	_, err := ParseReleaseTargets(nil, nil, []TargetConfig{
+		{Name: "public-api", Paths: []string{"services/api"}},
+		{Name: "public-api", Paths: []string{"libs/shared"}},
+	}, s.repoDir)
+
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), `both tag the package "public-api"`)
+}
+
+func (s *TaggingSuite) TestNamedTargetAndDirectoryCanNotShareAName() {
+	_, err := ParseReleaseTargets(
+		[]string{"services/api"},
+		nil,
+		[]TargetConfig{{Name: "api", Paths: []string{"libs/shared"}}},
+		s.repoDir,
+	)
+
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), `both tag the package "api"`)
+}
+
+func (s *TaggingSuite) TestNamedTargetAndDirectoryGroupCanNotShareAName() {
+	_, err := ParseReleaseTargets(
+		nil,
+		[]string{"services/api,libs/shared"},
+		[]TargetConfig{{Name: "api", Paths: []string{"services/worker"}}},
+		s.repoDir,
+	)
+
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), `both tag the package "api"`)
+}
+
+func (s *TaggingSuite) TestNamedTargetValidation() {
+	tests := []struct {
+		name   string
+		target TargetConfig
+		text   string
+	}{
+		{name: "empty name", target: TargetConfig{Paths: []string{"services/api"}}, text: "name must not be empty"},
+		{name: "empty paths", target: TargetConfig{Name: "api"}, text: "at least one path"},
+		{name: "empty path", target: TargetConfig{Name: "api", Paths: []string{""}}, text: "path must not be empty"},
+		{name: "absolute path", target: TargetConfig{Name: "api", Paths: []string{"/services/api"}}, text: "relative to the Git root"},
+		{name: "outside path", target: TargetConfig{Name: "api", Paths: []string{"../api"}}, text: "stay in the Git repository"},
+		{name: "backslash path", target: TargetConfig{Name: "api", Paths: []string{`services\api`}}, text: "forward slashes"},
+		{name: "comma name", target: TargetConfig{Name: "api,worker", Paths: []string{"services/api"}}, text: "not a safe Git tag prefix"},
+		{name: "equals name", target: TargetConfig{Name: "api=worker", Paths: []string{"services/api"}}, text: "not a safe Git tag prefix"},
+		{name: "slash name", target: TargetConfig{Name: "scope/api", Paths: []string{"services/api"}}, text: "not a safe Git tag prefix"},
+		{name: "dot sequence", target: TargetConfig{Name: "api..next", Paths: []string{"services/api"}}, text: "not a safe Git tag prefix"},
+		{name: "lock suffix", target: TargetConfig{Name: "api.lock", Paths: []string{"services/api"}}, text: "not a safe Git tag prefix"},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			_, err := ParseReleaseTargets(nil, nil, []TargetConfig{test.target}, s.repoDir)
+			require.Error(s.T(), err)
+			assert.Contains(s.T(), err.Error(), test.text)
+		})
+	}
+}
+
+func (s *TaggingSuite) TestNamedTargetNormalizesAndRemovesRepeatedPaths() {
+	groups, err := ParseReleaseTargets(nil, nil, []TargetConfig{{
+		Name:  "public-api",
+		Paths: []string{"services/api", "services/./api"},
+	}}, s.repoDir)
+
+	require.NoError(s.T(), err)
+	require.Len(s.T(), groups, 1)
+	assert.Equal(s.T(), []string{"services/api"}, groups[0].Directories)
+}
+
+func TestParseTargetSpecifications(t *testing.T) {
+	targets, err := ParseTargetSpecifications([]string{
+		"public-api=services/api,libs/shared",
+		"worker=services/worker",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []TargetConfig{
+		{Name: "public-api", Paths: []string{"services/api", "libs/shared"}},
+		{Name: "worker", Paths: []string{"services/worker"}},
+	}, targets)
+}
+
+func TestParseTargetSpecificationsRequiresEquals(t *testing.T) {
+	_, err := ParseTargetSpecifications([]string{"public-api"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name=path[,path...]")
 }
 
 // A tag that is not a version, such as "nightly", must not stop the run.

--- a/core/tagging_test.go
+++ b/core/tagging_test.go
@@ -6,8 +6,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/catalystcommunity/app-utils-go/logging"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -20,6 +23,7 @@ type TaggingSuite struct {
 	repoDir     string
 	previousDir string
 	commitCount int
+	lastOutput  string
 }
 
 func TestTaggingSuite(t *testing.T) {
@@ -31,6 +35,7 @@ func (s *TaggingSuite) SetupTest() {
 	require.NoError(s.T(), err)
 	s.previousDir = previousDir
 	s.commitCount = 0
+	s.lastOutput = ""
 
 	// macOS puts the temporary directory behind a symlink, and git reports the
 	// resolved path, so resolve it here to keep the two paths comparable.
@@ -133,9 +138,12 @@ func (s *TaggingSuite) runTagging(config Config) Outputs {
 
 	content, err := os.ReadFile(capturePath)
 	require.NoError(s.T(), err)
+	s.lastOutput = string(content)
+	jsonStart := strings.LastIndex(s.lastOutput, `{"New_release_published"`)
+	require.NotEqual(s.T(), -1, jsonStart)
 
 	outputs := Outputs{}
-	require.NoError(s.T(), json.Unmarshal(content, &outputs))
+	require.NoError(s.T(), json.Unmarshal([]byte(s.lastOutput[jsonStart:]), &outputs))
 	return outputs
 }
 
@@ -412,6 +420,82 @@ func (s *TaggingSuite) TestMultipleNamedTagsUseOneAtomicPush() {
 		require.NoError(s.T(), err)
 		assert.Equal(s.T(), s.headCommit(), string(content[:40]))
 	}
+	for _, tag := range []string{"public-api/v0.1", "public-api/v0"} {
+		check := exec.Command("git", "--git-dir", remoteDir, "show-ref", "--verify", "refs/tags/"+tag)
+		assert.Error(s.T(), check.Run())
+	}
+}
+
+func (s *TaggingSuite) TestShortVersionsMoveMajorAndMinorTags() {
+	firstHead := s.headCommit()
+	s.git("tag", "api/v1.3.6")
+	s.git("tag", "api/v1.3")
+	s.git("tag", "api/v1")
+
+	remoteDir := filepath.Join(s.T().TempDir(), "remote.git")
+	command := exec.Command("git", "init", "-q", "--bare", remoteDir)
+	require.NoError(s.T(), command.Run())
+	s.git("remote", "add", "origin", remoteDir)
+	s.git("push", "-q", "origin", "api/v1.3.6", "api/v1.3", "api/v1")
+
+	s.write("services/api/file.txt", "api change")
+	s.commit("fix: api change")
+	newHead := s.headCommit()
+	require.NotEqual(s.T(), firstHead, newHead)
+
+	outputs := s.runTagging(Config{
+		OutputJson:    true,
+		Atomic:        true,
+		Remote:        "origin",
+		Branch:        "",
+		ShortVersions: true,
+		Directories:   []string{"services/api"},
+	})
+
+	assert.Equal(s.T(), "api/v1.3.7", outputs.NewReleaseGitTag)
+	for _, tag := range []string{"api/v1.3.7", "api/v1.3", "api/v1"} {
+		check := exec.Command("git", "--git-dir", remoteDir, "rev-parse", "refs/tags/"+tag)
+		content, err := check.Output()
+		require.NoError(s.T(), err)
+		assert.Equal(s.T(), newHead, string(content[:40]))
+	}
+}
+
+func (s *TaggingSuite) TestShortVersionFlagsCannotConflict() {
+	err := DoTagging(Config{ShortVersions: true, SkipShortVersions: true})
+
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "cannot both be true")
+}
+
+func (s *TaggingSuite) TestDefaultShortVersionBehaviorWritesMigrationWarning() {
+	s.targetDryRun([]TargetConfig{{Name: "public-api", Paths: []string{"services/api"}}})
+
+	assert.Contains(s.T(), s.lastOutput, "Short version tags will become the default")
+	assert.Contains(s.T(), s.lastOutput, "--skip-short-versions")
+}
+
+func (s *TaggingSuite) TestSkipShortVersionsSuppressesMigrationWarning() {
+	s.runTagging(Config{
+		DryRun:            true,
+		OutputJson:        true,
+		SkipShortVersions: true,
+		Targets: []TargetConfig{{
+			Name: "public-api", Paths: []string{"services/api"},
+		}},
+	})
+
+	assert.NotContains(s.T(), s.lastOutput, "Short version tags will become the default")
+}
+
+func (s *TaggingSuite) TestErrorLogLevelSuppressesMigrationWarning() {
+	previousLevel := logging.Log.GetLevel()
+	logging.Log.SetLevel(logrus.ErrorLevel)
+	s.T().Cleanup(func() { logging.Log.SetLevel(previousLevel) })
+
+	s.targetDryRun([]TargetConfig{{Name: "public-api", Paths: []string{"services/api"}}})
+
+	assert.NotContains(s.T(), s.lastOutput, "Short version tags will become the default")
 }
 
 // A --directories value keeps its old meaning. It is one literal path, even
@@ -645,6 +729,30 @@ func (s *TaggingSuite) TestAllowedTypesLimitsWhatReleases() {
 
 	assert.Equal(s.T(), "false", outputs.NewReleasePublished)
 	assert.Equal(s.T(), "api/v1.0.0", outputs.NewReleaseGitTag)
+}
+
+func (s *TaggingSuite) TestArbitraryConfiguredTypeReleases() {
+	s.write("services/api/file.txt", "api change")
+	s.commit("holiday: bring joy")
+
+	outputs := s.runTagging(Config{
+		DryRun:      true,
+		OutputJson:  true,
+		PatchTypes:  []string{"holiday"},
+		Directories: []string{"services/api"},
+	})
+
+	assert.Equal(s.T(), "true", outputs.NewReleasePublished)
+	assert.Equal(s.T(), "api/v1.0.1", outputs.NewReleaseGitTag)
+}
+
+func (s *TaggingSuite) TestBreakingChangeFooterReleasesMajorVersion() {
+	s.write("services/api/file.txt", "api change")
+	s.commit("holiday: change the api\n\nBREAKING CHANGE: old clients cannot connect")
+
+	outputs := s.tagDryRun([]string{"services/api"}, nil)
+
+	assert.Equal(s.T(), "api/v2.0.0", outputs.NewReleaseGitTag)
 }
 
 func (s *TaggingSuite) TestCiAndPerfCommitsRelease() {


### PR DESCRIPTION
This allows complex directory naming to not be coupled with target tag names. Explicitly naming a target gives a lot of flexibility with monorepo evaluations with competing with wanting to structure directories the way makes sense for code (a higher priority for me and I hope most others)